### PR TITLE
Add CLI provider flags and stabilize test suite

### DIFF
--- a/src/cli/cli-core.ts
+++ b/src/cli/cli-core.ts
@@ -65,6 +65,16 @@ class CLI {
       type: 'string',
       default: 'info',
     },
+    {
+      name: 'provider',
+      description: 'Select LLM provider',
+      type: 'string',
+    },
+    {
+      name: 'tool-limit',
+      description: 'Limit number of tools per request',
+      type: 'number',
+    },
   ];
 
   constructor(
@@ -88,6 +98,13 @@ class CLI {
   async run(args = process.argv.slice(2)): Promise<void> {
     // Parse arguments manually since we're replacing the Deno parse function
     const flags = this.parseArgs(args);
+
+    if (flags.provider) {
+      process.env.DEFAULT_LLM_PROVIDER = String(flags.provider);
+    }
+    if (flags['tool-limit']) {
+      process.env.TOOL_LIMIT = String(flags['tool-limit']);
+    }
 
     if (flags.version || flags.v) {
       console.log(`${this.name} v${VERSION}`);

--- a/src/verification/tests/mocks/false-reporting-scenarios.test.ts
+++ b/src/verification/tests/mocks/false-reporting-scenarios.test.ts
@@ -15,6 +15,23 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 
+const deterministicRandom = (() => {
+  let seed = 42;
+  return () => {
+    const x = Math.sin(seed++) * 10000;
+    return x - Math.floor(x);
+  };
+})();
+let randomSpy: jest.SpyInstance<number, []>;
+
+beforeAll(() => {
+  randomSpy = jest.spyOn(Math, 'random').mockImplementation(deterministicRandom);
+});
+
+afterAll(() => {
+  randomSpy.mockRestore();
+});
+
 // Import verification components
 class TruthScoreCalculator {
   configPath!: string;


### PR DESCRIPTION
## Summary
- expose `--provider` and `--tool-limit` flags to set default provider and tool limit
- stabilize gaslighting detection tests with deterministic random sequence
- keep ExternalCLIProvider test and stable Jest config

## Testing
- `OPENAI_API_KEY="$OpenAiAPI" npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac4c87107883229de89514418768db