### PR TITLE
Add codex snake game generator example

### DIFF
--- a/examples/codex-snake/README.md
+++ b/examples/codex-snake/README.md
@@ -1,0 +1,18 @@
+# Codex Snake Game Example
+
+This example demonstrates using the OpenAI API (Codex) to generate a simple Snake game in Python.
+
+## Prerequisites
+- Node.js 20+
+- An OpenAI API key available as the `OPENAI_API_KEY` environment variable.
+
+## Usage
+```bash
+node generateSnakeGame.js
+```
+This will call the OpenAI API and write the resulting game code to `snake_game.py`.
+
+You can then run the game (requires a terminal environment that supports `curses`):
+```bash
+python snake_game.py
+```

--- a/examples/codex-snake/generateSnakeGame.js
+++ b/examples/codex-snake/generateSnakeGame.js
@@ -1,0 +1,39 @@
+import fs from 'fs';
+
+const apiKey = process.env.OPENAI_API_KEY;
+if (!apiKey) {
+  console.error('Error: OPENAI_API_KEY environment variable is not set.');
+  process.exit(1);
+}
+
+async function generate() {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      messages: [{
+        role: 'user',
+        content: 'Write a complete playable Python snake game that runs in the terminal using the curses module.'
+      }]
+    })
+  });
+
+  if (!response.ok) {
+    const errText = await response.text();
+    throw new Error(`OpenAI API error: ${errText}`);
+  }
+
+  const data = await response.json();
+  const code = data.choices?.[0]?.message?.content ?? '';
+  fs.writeFileSync(new URL('./snake_game.py', import.meta.url), code);
+  console.log('Snake game written to snake_game.py');
+}
+
+generate().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add example script that uses OpenAI Codex-compatible API to generate a terminal snake game
- document usage and environment requirements

## Testing
- `npm test`
- `node examples/codex-snake/generateSnakeGame.js` *(fails: OPENAI_API_KEY environment variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4f2a18dc83228212607f0a816527