### PR TITLE
feat: add CLI selection and API prompts

### DIFF
--- a/bin/claude-flow-swarm
+++ b/bin/claude-flow-swarm
@@ -1,31 +1,62 @@
 #!/bin/bash
 # Claude-Flow Swarm Mode Wrapper
-# This script wraps the swarm demo to work with the installed Deno
+# Provides runtime selection, optional installation, and API key configuration
 
-# Find deno in the path
-DENO_PATH=$(which deno 2>/dev/null || echo "/home/codespace/.deno/bin/deno")
+read -p "Select runtime (deno/node) [deno]: " RUNTIME
+RUNTIME=${RUNTIME:-deno}
 
-if [ ! -x "$DENO_PATH" ]; then
-    echo "Error: Deno is not installed or not in PATH"
-    echo "Please install Deno first: https://deno.land/#installation"
-    exit 1
+if [ "$RUNTIME" = "node" ]; then
+    CLI_PATH=$(command -v node 2>/dev/null)
+    if [ -z "$CLI_PATH" ]; then
+        read -p "Node.js not found. Install now? (y/N) " INSTALL_NODE
+        if [[ "$INSTALL_NODE" =~ ^[Yy]$ ]]; then
+            echo "Please install Node.js from https://nodejs.org/"
+        fi
+        echo "Node.js is required."; exit 1
+    fi
+else
+    CLI_PATH=$(command -v deno 2>/dev/null || echo "$HOME/.deno/bin/deno")
+    if [ ! -x "$CLI_PATH" ]; then
+        read -p "Deno not installed. Install now? (y/N) " INSTALL_DENO
+        if [[ "$INSTALL_DENO" =~ ^[Yy]$ ]]; then
+            curl -fsSL https://deno.land/install.sh | sh
+            CLI_PATH="$HOME/.deno/bin/deno"
+        else
+            echo "Deno is required."; exit 1
+        fi
+    fi
 fi
 
-# Get the directory of this script
+# API key setup
+if [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$CLAUDE_API_KEY" ]; then
+    echo "No API key found (ANTHROPIC_API_KEY or CLAUDE_API_KEY)."
+    read -p "Enter API key (leave empty to continue without): " INPUT_KEY
+    if [ -n "$INPUT_KEY" ]; then
+        export ANTHROPIC_API_KEY="$INPUT_KEY"
+        echo "API key set for current session."
+    else
+        echo "Continuing without API key."
+    fi
+fi
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Try to find swarm implementation in different locations
-if [ -f "$SCRIPT_DIR/../swarm-demo.ts" ]; then
-    # Local development path
-    SWARM_IMPL="$SCRIPT_DIR/../swarm-demo.ts"
-elif [ -f "$SCRIPT_DIR/../src/cli/swarm-standalone.js" ]; then
-    # Installed via npm - use the standalone JavaScript version
+if [ "$RUNTIME" = "node" ]; then
     SWARM_IMPL="$SCRIPT_DIR/../src/cli/swarm-standalone.js"
 else
-    echo "Error: Unable to find swarm implementation files"
-    echo "Please ensure claude-flow is properly installed"
-    exit 1
+    if [ -f "$SCRIPT_DIR/../swarm-demo.ts" ]; then
+        SWARM_IMPL="$SCRIPT_DIR/../swarm-demo.ts"
+    elif [ -f "$SCRIPT_DIR/../src/cli/swarm-standalone.js" ]; then
+        SWARM_IMPL="$SCRIPT_DIR/../src/cli/swarm-standalone.js"
+    else
+        echo "Error: Unable to find swarm implementation files"
+        echo "Please ensure claude-flow is properly installed"
+        exit 1
+    fi
 fi
 
-# Run the swarm implementation with all arguments
-exec "$DENO_PATH" run --allow-all "$SWARM_IMPL" "$@"
+if [ "$RUNTIME" = "node" ]; then
+    exec "$CLI_PATH" "$SWARM_IMPL" "$@"
+else
+    exec "$CLI_PATH" run --allow-all "$SWARM_IMPL" "$@"
+fi

--- a/src/cli/simple-commands/hive-mind.js
+++ b/src/cli/simple-commands/hive-mind.js
@@ -23,6 +23,7 @@ import {
   nonInteractiveProgress,
   nonInteractiveSelect,
 } from '../utils/safe-interactive.js';
+import { ensureCliAndApiKey } from '../utils/cli-env.js';
 
 // Import SQLite for persistence
 import Database from 'better-sqlite3';
@@ -38,6 +39,9 @@ import { CollectiveMemory } from './hive-mind/memory.js';
 import { SwarmCommunication } from './hive-mind/communication.js';
 import { HiveMindSessionManager } from './hive-mind/session-manager.js';
 import { createAutoSaveMiddleware } from './hive-mind/auto-save-middleware.js';
+
+// Ensure required CLI runtime and API key are available
+await ensureCliAndApiKey();
 
 function showHiveMindHelp() {
   console.log(`

--- a/src/cli/swarm-standalone.js
+++ b/src/cli/swarm-standalone.js
@@ -16,11 +16,13 @@ const __dirname = dirname(__filename);
 const args = [];
 const flags = {};
 
-for (let i = 0; i < Deno.args.length; i++) {
-  const arg = Deno.args[i];
-  if (arg.startsWith('--')) {
-    const flagName = arg.substring(2);
-    const nextArg = Deno.args[i + 1];
+const runtimeArgs = typeof Deno !== 'undefined' ? Deno.args : process.argv.slice(2);
+
+  for (let i = 0; i < runtimeArgs.length; i++) {
+    const arg = runtimeArgs[i];
+    if (arg.startsWith('--')) {
+      const flagName = arg.substring(2);
+      const nextArg = runtimeArgs[i + 1];
 
     if (nextArg && !nextArg.startsWith('--')) {
       flags[flagName] = nextArg;

--- a/src/cli/utils/cli-env.js
+++ b/src/cli/utils/cli-env.js
@@ -1,0 +1,99 @@
+import { spawnSync, spawn } from 'child_process';
+import inquirer from 'inquirer';
+import chalk from 'chalk';
+
+function checkCommand(cmd) {
+  const result = spawnSync('command', ['-v', cmd], { stdio: 'ignore' });
+  return result.status === 0;
+}
+
+async function promptInstall(cli) {
+  const { install } = await inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'install',
+      message: `${cli} is not installed. Install now?`,
+      default: false,
+    },
+  ]);
+  if (!install) {
+    console.log(chalk.red(`${cli} is required.`));
+    process.exit(1);
+  }
+  if (cli === 'deno') {
+    await new Promise((resolve, reject) => {
+      const sh = spawn('sh', ['-c', 'curl -fsSL https://deno.land/install.sh | sh'], {
+        stdio: 'inherit',
+      });
+      sh.on('exit', (code) => {
+        if (code === 0) resolve();
+        else reject(new Error('Failed to install deno'));
+      });
+    });
+  } else {
+    console.log(
+      chalk.yellow(
+        'Please install Node.js from https://nodejs.org/ and rerun the command.'
+      )
+    );
+    process.exit(1);
+  }
+}
+
+export async function ensureCliAndApiKey() {
+  const available = [];
+  if (checkCommand('deno')) available.push('deno');
+  if (checkCommand('node')) available.push('node');
+
+  let cli = 'node';
+  if (available.length === 0) {
+    const { choice } = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'choice',
+        message: 'No CLI detected. Which one would you like to set up?',
+        choices: ['deno', 'node'],
+      },
+    ]);
+    cli = choice;
+    await promptInstall(cli);
+  } else if (available.length === 1) {
+    cli = available[0];
+  } else {
+    const { choice } = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'choice',
+        message: 'Select CLI runtime to use',
+        choices: available,
+      },
+    ]);
+    cli = choice;
+  }
+
+  if (!checkCommand(cli)) {
+    await promptInstall(cli);
+  }
+
+  if (!process.env.ANTHROPIC_API_KEY && !process.env.CLAUDE_API_KEY) {
+    const { apiKey } = await inquirer.prompt([
+      {
+        type: 'password',
+        name: 'apiKey',
+        message: 'Enter your API key (leave blank to skip)',
+      },
+    ]);
+    if (apiKey) {
+      process.env.ANTHROPIC_API_KEY = apiKey;
+      console.log(chalk.green('API key set for current session.'));
+    } else {
+      console.log(
+        chalk.yellow(
+          'No API key provided. Set ANTHROPIC_API_KEY or CLAUDE_API_KEY for full functionality.'
+        )
+      );
+    }
+  }
+
+  return cli;
+}


### PR DESCRIPTION
## Summary
- add utility to select CLI runtime and prompt for API key
- integrate runtime and API checks into hive mind command
- support Node argument parsing in swarm standalone and add interactive swarm wrapper

## Testing
- `npm run test:cli -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ac58a9e1bc83229f9bcccc43d31eda